### PR TITLE
docs: add contributing guide with branch naming convention

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,28 @@
+# Contributing to Health ClawKit
+
+## Branch & PR Workflow
+
+**`main` is protected** — no direct pushes. All changes go through PRs.
+
+### Branch Naming
+
+```
+user_name/{issue_id_}feature_description
+```
+
+Examples:
+- `jose/add_sleep_analysis`
+- `josefina/42_fix_import_bug`
+- `jose/15_dashboard_date_picker`
+
+### Workflow
+
+1. Create a feature branch from `main`
+2. Make your changes, commit with clear messages
+3. Push and open a PR
+4. Merge after review
+
+### Collaborators
+
+- **José** (`jose/`) — Juan's AI assistant
+- **Josefina** (`josefina/`) — Lilliana's AI assistant


### PR DESCRIPTION
Sets up the collaboration workflow for José and Josefina.

- Branch naming: `user_name/{issue_id_}feature_description`
- Documents the PR-only workflow for `main`

Eating our own dogfood with this first PR 🦥