### PR TITLE
feat: add CycleTracking CSV importer

### DIFF
--- a/src/daily_import.py
+++ b/src/daily_import.py
@@ -22,6 +22,7 @@ sys.path.insert(0, str(Path(__file__).parent))
 from import_healthkit import import_csv
 from import_medications import import_medications_csv
 from import_workouts import import_workouts_csv
+from import_cycletracking import import_cycletracking_csv
 from validate import run_validation
 from config import get_db_path, get_icloud_folder
 
@@ -115,6 +116,8 @@ def run_daily_import(dry_run=False):
             rows = import_medications_csv(csv_file)
         elif csv_file.name.startswith("Workouts-"):
             rows = import_workouts_csv(csv_file)
+        elif csv_file.name.startswith("CycleTracking-"):
+            rows = import_cycletracking_csv(csv_file)
         elif csv_file.name.startswith("HealthMetrics-"):
             rows = import_csv(csv_file)
         elif csv_file.name.startswith("HaishanYe_glucose_"):

--- a/src/import_cycletracking.py
+++ b/src/import_cycletracking.py
@@ -1,0 +1,166 @@
+#!/usr/bin/env python3
+"""
+Import Health Auto Export CycleTracking CSV files into DuckDB.
+
+CycleTracking CSVs have a different schema than HealthMetrics:
+- Columns: Start, End, Data, Value, Cycle Start
+- Uses "Start" as the timestamp
+- Stores in readings table with metric names like "Cycle Tracking - Menstrual Flow"
+
+Usage:
+    python src/import_cycletracking.py <csv_file>
+"""
+
+import duckdb
+import pandas as pd
+import sys
+from pathlib import Path
+from datetime import datetime
+from config import get_db_path
+
+DB_PATH = get_db_path()
+
+
+def import_cycletracking_csv(csv_path):
+    """
+    Import a CycleTracking CSV into DuckDB readings table.
+    
+    Args:
+        csv_path: Path to CycleTracking CSV file
+    
+    Returns:
+        int: Number of rows imported, or -1 on error
+    """
+    csv_path = Path(csv_path)
+    if not csv_path.exists():
+        print(f"❌ File not found: {csv_path}")
+        return -1
+
+    filename = csv_path.name
+    conn = duckdb.connect(str(DB_PATH))
+
+    try:
+        # Check if already imported
+        existing = conn.execute(
+            "SELECT import_id FROM imports WHERE filename = ?", [filename]
+        ).fetchone()
+        if existing:
+            print(f"⏭️  Already imported: {filename} (import_id={existing[0]})")
+            return 0
+
+        print(f"📖 Reading: {filename}")
+        df = pd.read_csv(csv_path)
+
+        # Verify required columns exist
+        required_cols = ['Start', 'Data', 'Value']
+        missing_cols = [col for col in required_cols if col not in df.columns]
+        if missing_cols:
+            print(f"❌ Missing required columns: {', '.join(missing_cols)}")
+            return -1
+
+        # Convert Start to datetime
+        df['Start'] = pd.to_datetime(df['Start'], errors='coerce')
+        
+        # Drop rows with invalid timestamps or missing data
+        df = df.dropna(subset=['Start', 'Data', 'Value'])
+
+        print(f"🩸 Found {len(df)} cycle tracking records")
+
+        # Transform to readings format
+        # Metric name format: "Cycle Tracking - {Data}"
+        # e.g., "Cycle Tracking - Menstrual Flow"
+        records = []
+        for _, row in df.iterrows():
+            metric_name = f"Cycle Tracking - {row['Data']}"
+            
+            # Store the value as-is (might be text like "Unspecified", "Light", etc.)
+            # For numeric compatibility, we'll encode text values
+            value_str = str(row['Value'])
+            
+            # Try to convert to numeric, otherwise encode common values
+            try:
+                numeric_value = float(value_str)
+            except ValueError:
+                # Encode text values to numbers for storage
+                # This allows querying while preserving the meaning
+                value_mapping = {
+                    'Unspecified': 0.0,
+                    'Light': 1.0,
+                    'Medium': 2.0,
+                    'Heavy': 3.0,
+                    'None': 0.0,
+                    'Yes': 1.0,
+                    'No': 0.0,
+                }
+                numeric_value = value_mapping.get(value_str, 0.0)
+            
+            records.append({
+                'timestamp': row['Start'],
+                'metric': metric_name,
+                'value': numeric_value,
+                'unit': value_str,  # Store original value in unit field for reference
+                'source': 'cycletracking'
+            })
+
+        df_insert = pd.DataFrame(records)
+        
+        # Insert into readings table
+        rows_before = conn.execute("SELECT COUNT(*) FROM readings").fetchone()[0]
+
+        conn.execute("""
+            INSERT OR IGNORE INTO readings (timestamp, metric, value, unit, source)
+            SELECT timestamp, metric, value, unit, source
+            FROM df_insert
+        """)
+
+        rows_after = conn.execute("SELECT COUNT(*) FROM readings").fetchone()[0]
+        rows_added = rows_after - rows_before
+
+        # Log import
+        conn.execute("""
+            INSERT INTO imports (filename, imported_at, rows_added, source)
+            VALUES (?, ?, ?, 'cycletracking')
+        """, [filename, datetime.now(), rows_added])
+
+        import_id = conn.execute(
+            "SELECT import_id FROM imports WHERE filename = ?", [filename]
+        ).fetchone()[0]
+
+        print(f"✅ Imported {rows_added} cycle tracking readings (import_id={import_id})")
+        
+        # Show sample of what was imported
+        if rows_added > 0:
+            sample = conn.execute("""
+                SELECT metric, COUNT(*) as count
+                FROM readings
+                WHERE source = 'cycletracking'
+                GROUP BY metric
+                ORDER BY count DESC
+                LIMIT 5
+            """).fetchall()
+            
+            if sample:
+                print(f"📊 Metrics imported:")
+                for metric, count in sample:
+                    print(f"   - {metric}: {count} readings")
+
+        return rows_added
+
+    except Exception as e:
+        print(f"❌ Error importing {filename}: {e}")
+        import traceback
+        traceback.print_exc()
+        return -1
+    finally:
+        conn.close()
+
+
+if __name__ == "__main__":
+    if len(sys.argv) < 2:
+        print("Usage: python src/import_cycletracking.py <csv_file>")
+        print("\nExample:")
+        print('  python src/import_cycletracking.py "/path/to/CycleTracking-2026-01-20.csv"')
+        sys.exit(1)
+    
+    rows = import_cycletracking_csv(sys.argv[1])
+    sys.exit(0 if rows >= 0 else 1)


### PR DESCRIPTION
## Summary
Adds support for importing CycleTracking CSV files from Health Auto Export.

## Changes
- New `src/import_cycletracking.py` - handles CycleTracking schema (Start, End, Data, Value, Cycle Start)
- Updated `src/daily_import.py` to route CycleTracking-*.csv files to the new importer

## Details
- Uses `Start` column as timestamp (CycleTracking doesn't have `Date/Time`)
- Encodes flow values: Unspecified=0, Light=1, Medium=2, Heavy=3
- Preserves original text in `unit` field for reference
- Follows same pattern as `import_workouts.py`

## Testing
- ✅ Imported CycleTracking-2026-01-20.csv (1 reading)
- ✅ Idempotency verified (re-run skips already imported)
- ✅ Database verification passed